### PR TITLE
quickfix for #1

### DIFF
--- a/src/com/verilang/psi/SimpleIdentifierReference.java
+++ b/src/com/verilang/psi/SimpleIdentifierReference.java
@@ -98,10 +98,12 @@ public class SimpleIdentifierReference extends PsiReferenceBase.Poly<SimpleIdent
                 )
                 .stream()
                 .map(virtualFile ->
-                        (VerilogFile) PsiManager
+                        PsiManager
                                 .getInstance(myElement.getProject())
                                 .findFile(virtualFile))
                 .filter(Objects::nonNull)
+                .filter(psiFile -> psiFile instanceof VerilogFile)
+                .map(psiFile -> (VerilogFile) psiFile)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
although there is still a thing to do in #1: there is a deprecation warning on 

https://github.com/MrTsepa/jetbrains-verilog-plugin/blob/f705c36b54e7de4945e5925ee9a73d6989e2689d/src/com/verilang/psi/SimpleIdentifierReference.java#L95

which probably leads to this error